### PR TITLE
Document Vercel deployment and set up image hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Creepy Society
 
-Minimal static comic site built with Next.js App Router, Tailwind CSS and MDX.
+Minimal comic site built with Next.js App Router, Tailwind CSS and MDX.
 
 ## Content model
 
@@ -8,10 +8,11 @@ Minimal static comic site built with Next.js App Router, Tailwind CSS and MDX.
 /content/stories/<slug>/
   story.mdx        # panels + text
   archive.json     # citations
-  /panels/*        # optional art assets
 ```
 
-Sample story uses an inline placeholder instead of an image.
+Panel images live in `public/stories/<slug>` and are served with the Next.js `<Image>` component.
+
+Sample story demonstrates using the Next.js `<Image>` component and a panel image stored in `public/stories/sample/scarecrow.jpg`.
 
 ## Local development
 
@@ -32,6 +33,17 @@ npm run build
 
 ## Deployment
 
-`npm run build` exports the site to the `out/` directory.
-Upload this folder to any static host such as Vercel or Cloudflare Pages.
-Use `npm start` to preview the static build locally.
+### Vercel
+
+1. [Install the Vercel CLI](https://vercel.com/docs/cli) or connect this repo in the Vercel dashboard.
+2. Set the build command to `npm run build`.
+3. Deploy with `vercel` or push to the connected Git repository.
+
+Story assets in `/content` are copied into the `public/` directory during `npm run build`, allowing the `<Image>` component to serve them with Vercel's image optimization.
+
+### Previewing locally
+
+```bash
+npm run build
+npm start
+```

--- a/app/stories/[slug]/page.tsx
+++ b/app/stories/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { compileMDX } from 'next-mdx-remote/rsc'
+import Image from 'next/image'
 
 export async function generateStaticParams() {
   const storiesDir = path.join(process.cwd(), 'content', 'stories')
@@ -12,7 +13,7 @@ export default async function StoryPage({ params }: { params: Promise<{ slug: st
   const { slug } = await params
   const storyDir = path.join(process.cwd(), 'content', 'stories', slug)
   const source = await fs.promises.readFile(path.join(storyDir, 'story.mdx'), 'utf8')
-  const { content } = await compileMDX({ source, options: { parseFrontmatter: true } })
+  const { content } = await compileMDX({ source, components: { Image }, options: { parseFrontmatter: true } })
   const archive = JSON.parse(await fs.promises.readFile(path.join(storyDir, 'archive.json'), 'utf8'))
   return (
     <main className="prose mx-auto p-4">

--- a/content/stories/sample/story.mdx
+++ b/content/stories/sample/story.mdx
@@ -1,7 +1,11 @@
 # Sample Story
 
-<div className="w-full h-40 flex items-center justify-center bg-gray-200">
-  Panel 1 placeholder
-</div>
+<Image
+  src="/stories/sample/scarecrow.jpg"
+  alt="Scarecrow"
+  width={400}
+  height={200}
+  className="w-full h-auto"
+/> 
 
 This is a tiny panel.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from 'next'
 
-const nextConfig: NextConfig = {
-  output: 'export'
-}
+const nextConfig: NextConfig = {}
 
 export default nextConfig

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "copy-content": "node scripts/copy-content.mjs",
     "dev": "npm run copy-content && next dev",
     "build": "npm run copy-content && next build",
-    "start": "npx serve@latest out",
+    "start": "next start",
     "lint": "next lint",
     "test": "echo \"No tests\""
   },

--- a/scripts/copy-content.mjs
+++ b/scripts/copy-content.mjs
@@ -4,5 +4,4 @@ import path from 'path'
 const src = path.join(process.cwd(), 'content', 'stories')
 const dest = path.join(process.cwd(), 'public', 'stories')
 
-fs.rmSync(dest, { recursive: true, force: true })
 fs.cpSync(src, dest, { recursive: true })


### PR DESCRIPTION
## Summary
- document Vercel deployment steps and local preview flow
- serve panel art with Next.js `Image` and copy assets for optimization on Vercel
- switch to `next start` and drop static export
- wire sample story to `/public/stories/sample/scarecrow.jpg` and preserve uploaded images during content copy

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bedb295690832a87ce53b629973ebc