### PR TITLE
style: comic styling for panel backs

### DIFF
--- a/components/ComicPanel.tsx
+++ b/components/ComicPanel.tsx
@@ -19,8 +19,8 @@ export default function ComicPanel({ src, alt, width, height, history }: ComicPa
         <div className="[backface-visibility:hidden]">
           <Image src={src} alt={alt} width={width} height={height} className="w-full h-auto" />
         </div>
-        <div className="absolute inset-0 flex items-center justify-center bg-white p-4 text-center [transform:rotateY(180deg)] [backface-visibility:hidden]">
-          <p>{history}</p>
+        <div className="absolute inset-0 flex items-center justify-center bg-gray-100 p-4 text-center text-black [transform:rotateY(180deg)] [backface-visibility:hidden]">
+          <p className="font-comic">{history}</p>
         </div>
       </div>
     </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,7 +3,11 @@ import type { Config } from 'tailwindcss'
 const config: Config = {
   content: ["./app/**/*.{ts,tsx,mdx}", "./content/**/*.{mdx,md}", "./components/**/*.{ts,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        comic: ['"Comic Sans MS"', 'Comic Sans', 'cursive'],
+      },
+    },
   },
   plugins: [require('@tailwindcss/typography')],
 }


### PR DESCRIPTION
## Summary
- style comic panel backs with light gray background and black text
- add comic-style font for back text

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bef0a78054832aa8728c0989abc0fe