### PR TITLE
feat: display logo on home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,8 @@
 import fs from 'fs'
 import path from 'path'
+import Image from 'next/image'
 import Link from 'next/link'
+import logo from '@/content/logo.png'
 
 async function getStories() {
   const storiesDir = path.join(process.cwd(), 'content', 'stories')
@@ -16,6 +18,7 @@ export default async function Home() {
   const stories = await getStories()
   return (
     <main className="p-4 prose">
+      <Image src={logo} alt="Site logo" className="mb-4" />
       <h1>Stories</h1>
       <ul>
         {stories.map(slug => (


### PR DESCRIPTION
## Summary
- show site logo on the home page using next/image

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bef37df1f8832aa17aa2d1535d590a