### PR TITLE
feat: support multi-page stories

### DIFF
--- a/app/stories/[slug]/[page]/page.tsx
+++ b/app/stories/[slug]/[page]/page.tsx
@@ -1,0 +1,132 @@
+import fs from 'fs'
+import path from 'path'
+import { compileMDX } from 'next-mdx-remote/rsc'
+import ComicPanel from '@/components/ComicPanel'
+import Link from 'next/link'
+
+async function getPageNumbers(storyDir: string): Promise<number[]> {
+  const files = await fs.promises.readdir(storyDir)
+  const pages = files
+    .filter(f => f.endsWith('.mdx'))
+    .map(f => {
+      if (f === 'story.mdx') return 1
+      const match = f.match(/(\d+)/)
+      return match ? Number(match[1]) : NaN
+    })
+    .filter(n => !Number.isNaN(n))
+  return Array.from(new Set(pages)).sort((a, b) => a - b)
+}
+
+async function getPageFile(storyDir: string, page: number): Promise<string> {
+  const candidates = [`page-${page}.mdx`, `page${page}.mdx`, `${page}.mdx`]
+  if (page === 1) candidates.push('story.mdx')
+  for (const name of candidates) {
+    const full = path.join(storyDir, name)
+    try {
+      await fs.promises.access(full)
+      return full
+    } catch {}
+  }
+  throw new Error(`Page file for page ${page} not found`)
+}
+
+export async function generateStaticParams() {
+  const storiesDir = path.join(process.cwd(), 'content', 'stories')
+  const entries = await fs.promises.readdir(storiesDir, { withFileTypes: true })
+  const params: { slug: string; page: string }[] = []
+  for (const entry of entries.filter(e => e.isDirectory())) {
+    const storyDir = path.join(storiesDir, entry.name)
+    const pages = await getPageNumbers(storyDir)
+    if (pages.length === 0) {
+      params.push({ slug: entry.name, page: '1' })
+    } else {
+      params.push(...pages.map(p => ({ slug: entry.name, page: p.toString() })))
+    }
+  }
+  return params
+}
+
+export default async function StoryPage({ params }: { params: Promise<{ slug: string; page: string }> }) {
+  const { slug, page } = await params
+  const storiesDir = path.join(process.cwd(), 'content', 'stories')
+  const entries = await fs.promises.readdir(storiesDir, { withFileTypes: true })
+  const slugs = entries.filter(e => e.isDirectory()).map(e => e.name).sort()
+  const currentSlugIndex = slugs.indexOf(slug)
+  const prevSlug = currentSlugIndex > 0 ? slugs[currentSlugIndex - 1] : null
+  const nextSlug = currentSlugIndex < slugs.length - 1 ? slugs[currentSlugIndex + 1] : null
+
+  const storyDir = path.join(storiesDir, slug)
+  const pageNum = Number(page)
+  const pages = await getPageNumbers(storyDir)
+  const currentPageIndex = pages.indexOf(pageNum)
+  const prevPage = currentPageIndex > 0 ? pages[currentPageIndex - 1] : null
+  const nextPage = currentPageIndex < pages.length - 1 ? pages[currentPageIndex + 1] : null
+
+  let prevLink: string | null = null
+  if (prevPage !== null) {
+    prevLink = `/stories/${slug}/${prevPage}`
+  } else if (prevSlug) {
+    const prevPages = await getPageNumbers(path.join(storiesDir, prevSlug))
+    const lastPage = prevPages[prevPages.length - 1] || 1
+    prevLink = `/stories/${prevSlug}/${lastPage}`
+  }
+
+  let nextLink: string | null = null
+  if (nextPage !== null) {
+    nextLink = `/stories/${slug}/${nextPage}`
+  } else if (nextSlug) {
+    const nextPages = await getPageNumbers(path.join(storiesDir, nextSlug))
+    const firstPage = nextPages[0] || 1
+    nextLink = `/stories/${nextSlug}/${firstPage}`
+  }
+
+  const pageFile = await getPageFile(storyDir, pageNum)
+  const source = await fs.promises.readFile(pageFile, 'utf8')
+
+  interface ArchiveEntry {
+    panel: number
+    citation: string
+  }
+  const archive: ArchiveEntry[] = JSON.parse(
+    await fs.promises.readFile(path.join(storyDir, 'archive.json'), 'utf8')
+  )
+
+  interface WrapperProps {
+    panel: number
+    src: string
+    alt: string
+    width: number
+    height: number
+  }
+
+  const components = {
+    ComicPanel: (props: WrapperProps) => {
+      const historyEntry = archive.find(entry => entry.panel === Number(props.panel))
+      return <ComicPanel {...props} history={historyEntry?.citation ?? ''} />
+    }
+  }
+
+  const { content } = await compileMDX({ source, components, options: { parseFrontmatter: true } })
+  return (
+    <main className="prose mx-auto px-4 pt-8 text-center flex flex-col items-center">
+      {content}
+      <nav className="mt-8 w-full max-w-3xl flex justify-between">
+        {prevLink ? (
+          <Link href={prevLink} className="underline">
+            Previous
+          </Link>
+        ) : (
+          <span />
+        )}
+        {nextLink ? (
+          <Link href={nextLink} className="underline">
+            Next
+          </Link>
+        ) : (
+          <span />
+        )}
+      </nav>
+    </main>
+  )
+}
+

--- a/app/stories/[slug]/page.tsx
+++ b/app/stories/[slug]/page.tsx
@@ -1,67 +1,7 @@
-import fs from 'fs'
-import path from 'path'
-import { compileMDX } from 'next-mdx-remote/rsc'
-import ComicPanel from '@/components/ComicPanel'
-import Link from 'next/link'
+export { generateStaticParams } from './[page]/page'
+import { redirect } from 'next/navigation'
 
-export async function generateStaticParams() {
-  const storiesDir = path.join(process.cwd(), 'content', 'stories')
-  const entries = await fs.promises.readdir(storiesDir, { withFileTypes: true })
-  return entries.filter(e => e.isDirectory()).map(e => ({ slug: e.name }))
-}
-
-export default async function StoryPage({ params }: { params: Promise<{ slug: string }> }) {
+export default async function StorySlugRedirect({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params
-  const storiesDir = path.join(process.cwd(), 'content', 'stories')
-  const entries = await fs.promises.readdir(storiesDir, { withFileTypes: true })
-  const slugs = entries.filter(e => e.isDirectory()).map(e => e.name).sort()
-  const currentIndex = slugs.indexOf(slug)
-  const prevSlug = currentIndex > 0 ? slugs[currentIndex - 1] : null
-  const nextSlug = currentIndex < slugs.length - 1 ? slugs[currentIndex + 1] : null
-  const storyDir = path.join(storiesDir, slug)
-  const source = await fs.promises.readFile(path.join(storyDir, 'story.mdx'), 'utf8')
-  interface ArchiveEntry {
-    panel: number
-    citation: string
-  }
-
-  const archive: ArchiveEntry[] = JSON.parse(await fs.promises.readFile(path.join(storyDir, 'archive.json'), 'utf8'))
-
-  interface WrapperProps {
-    panel: number
-    src: string
-    alt: string
-    width: number
-    height: number
-  }
-
-  const components = {
-    ComicPanel: (props: WrapperProps) => {
-      const historyEntry = archive.find(entry => entry.panel === Number(props.panel))
-      return <ComicPanel {...props} history={historyEntry?.citation ?? ''} />
-    }
-  }
-
-  const { content } = await compileMDX({ source, components, options: { parseFrontmatter: true } })
-  return (
-    <main className="prose mx-auto px-4 pt-8 text-center flex flex-col items-center">
-      {content}
-      <nav className="mt-8 w-full max-w-3xl flex justify-between">
-        {prevSlug ? (
-          <Link href={`/stories/${prevSlug}`} className="underline">
-            Previous
-          </Link>
-        ) : (
-          <span />
-        )}
-        {nextSlug ? (
-          <Link href={`/stories/${nextSlug}`} className="underline">
-            Next
-          </Link>
-        ) : (
-          <span />
-        )}
-      </nav>
-    </main>
-  )
+  redirect(`/stories/${slug}/1`)
 }

--- a/components/StoryCarousel.tsx
+++ b/components/StoryCarousel.tsx
@@ -16,7 +16,7 @@ export default function StoryCarousel({ stories }: { stories: Story[] }) {
             key={slug}
             className="relative w-48 h-48 md:w-56 md:h-56 lg:w-60 lg:h-60 flex-shrink-0 snap-start"
           >
-            <Link href={`/stories/${slug}`} className="block w-full h-full">
+            <Link href={`/stories/${slug}/1`} className="block w-full h-full">
               <Image
                 src={`/stories/${slug}/${cover}`}
                 alt={title}


### PR DESCRIPTION
## Summary
- allow stories to span multiple MDX pages with page-by-page navigation
- redirect `/stories/[slug]` to the first page and update carousel links

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c082db5060832ab51f9d0365702743