### PR TITLE
Display comic panels horizontally with back link

### DIFF
--- a/app/stories/[slug]/[page]/page.tsx
+++ b/app/stories/[slug]/[page]/page.tsx
@@ -108,7 +108,10 @@ export default async function StoryPage({ params }: { params: Promise<{ slug: st
 
   const { content } = await compileMDX({ source, components, options: { parseFrontmatter: true } })
   return (
-    <main className="prose mx-auto px-4 pt-8 text-center flex flex-col items-center">
+    <main className="prose mx-auto px-4 pt-8 flex flex-col text-left">
+      <Link href="/" className="fixed top-4 left-4 underline">
+        Back to main page
+      </Link>
       {content}
       <nav className="mt-8 w-full max-w-3xl flex justify-between">
         {prevLink ? (

--- a/components/ComicPanel.tsx
+++ b/components/ComicPanel.tsx
@@ -17,7 +17,7 @@ export default function ComicPanel({ src, alt, width, height, history }: ComicPa
   const scaledHeight = height * 2
   return (
     <div
-      className="cursor-pointer [perspective:1000px] mx-auto mt-4"
+      className="cursor-pointer [perspective:1000px] inline-block m-4"
       style={{ width: scaledWidth, height: scaledHeight }}
       onClick={() => setFlipped(f => !f)}
     >


### PR DESCRIPTION
## Summary
- show comic panels inline so multiple panels render left-to-right
- add fixed top-left link to return to main page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c08f090288832a84fba34c724211bf