### PR TITLE
Allow spaces in story titles

### DIFF
--- a/content/stories/s-w/story.mdx
+++ b/content/stories/s-w/story.mdx
@@ -1,3 +1,8 @@
+---
+title: S & W
+cover: s_and_w.jpg
+---
+
 # S&W
 
 <ComicPanel

--- a/content/stories/scarecrow/story.mdx
+++ b/content/stories/scarecrow/story.mdx
@@ -1,3 +1,8 @@
+---
+title: Scarecrow Story
+cover: cover.jpg
+---
+
 # Scarecrow Story
 
 <ComicPanel


### PR DESCRIPTION
## Summary
- derive story titles and cover images from front matter instead of slug
- add sample front matter to existing stories

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c095b72244832a91c1ae0073bd8eae