### PR TITLE
Standardize comic panel dimensions

### DIFF
--- a/components/ComicPanel.tsx
+++ b/components/ComicPanel.tsx
@@ -11,30 +11,40 @@ interface ComicPanelProps {
   history: string
 }
 
+const PANEL_WIDTH = 800
+
 export default function ComicPanel({ src, alt, width, height, history }: ComicPanelProps) {
   const [flipped, setFlipped] = useState(false)
-  const scaledWidth = width * 2
-  const scaledHeight = height * 2
+  const panelHeight = Math.round((height / width) * PANEL_WIDTH)
+
   return (
     <div
       className="cursor-pointer [perspective:1000px] inline-block m-4"
-      style={{ width: scaledWidth, height: scaledHeight }}
+      style={{ width: PANEL_WIDTH, height: panelHeight, boxSizing: 'border-box' }}
       onClick={() => setFlipped(f => !f)}
     >
       <div
-        className={`relative w-full h-full transition-transform duration-500 [transform-style:preserve-3d] ${flipped ? '[transform:rotateY(180deg)]' : ''}`}
+        className={`relative w-full h-full transition-transform duration-500 [transform-style:preserve-3d] ${
+          flipped ? '[transform:rotateY(180deg)]' : ''
+        }`}
       >
-        <div className="[backface-visibility:hidden] absolute inset-0 w-full h-full">
+        <div
+          className="[backface-visibility:hidden] absolute inset-0 w-full h-full"
+          style={{ width: PANEL_WIDTH, height: panelHeight, boxSizing: 'border-box' }}
+        >
           <Image
             src={src}
             alt={alt}
-            width={scaledWidth}
-            height={scaledHeight}
+            width={PANEL_WIDTH}
+            height={panelHeight}
             className="w-full h-full object-contain"
           />
         </div>
-        <div className="absolute inset-0 w-full h-full flex items-center justify-center bg-gray-100 p-4 text-center text-black overflow-auto [transform:rotateY(180deg)] [backface-visibility:hidden]">
-          <p className="font-comic">{history}</p>
+        <div
+          className="absolute inset-0 w-full h-full flex items-center justify-center bg-gray-100 p-4 text-center text-black overflow-auto [transform:rotateY(180deg)] [backface-visibility:hidden]"
+          style={{ width: PANEL_WIDTH, height: panelHeight, boxSizing: 'border-box' }}
+        >
+          <p className="font-comic m-0">{history}</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- enforce border-box sizing and remove paragraph margins so flipped backs match fronts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0bd046ce4832abe952697e14cd81d