### PR TITLE
refactor: make ComicPanel responsive

### DIFF
--- a/components/ComicPanel.tsx
+++ b/components/ComicPanel.tsx
@@ -11,39 +11,32 @@ interface ComicPanelProps {
   history: string
 }
 
-const PANEL_WIDTH = 800
-
 export default function ComicPanel({ src, alt, width, height, history }: ComicPanelProps) {
   const [flipped, setFlipped] = useState(false)
-  const panelHeight = Math.round((height / width) * PANEL_WIDTH)
+  const aspect = width / height
 
   return (
     <div
-      className="cursor-pointer [perspective:1000px] inline-block m-4"
-      style={{ width: PANEL_WIDTH, height: panelHeight, boxSizing: 'border-box' }}
+      className="cursor-pointer [perspective:1000px] inline-block m-4 w-full max-w-[800px] relative"
+      style={{ aspectRatio: aspect }}
       onClick={() => setFlipped(f => !f)}
     >
       <div
-        className={`relative w-full h-full transition-transform duration-500 [transform-style:preserve-3d] ${
+        className={`absolute inset-0 w-full h-full transition-transform duration-500 [transform-style:preserve-3d] ${
           flipped ? '[transform:rotateY(180deg)]' : ''
         }`}
       >
-        <div
-          className="[backface-visibility:hidden] absolute inset-0 w-full h-full"
-          style={{ width: PANEL_WIDTH, height: panelHeight, boxSizing: 'border-box' }}
-        >
+        <div className="[backface-visibility:hidden] absolute inset-0 w-full h-full">
           <Image
             src={src}
             alt={alt}
-            width={PANEL_WIDTH}
-            height={panelHeight}
-            className="w-full h-full object-contain"
+            fill
+            priority
+            className="object-contain"
+            sizes="(max-width: 800px) 100vw, 800px"
           />
         </div>
-        <div
-          className="absolute inset-0 w-full h-full flex items-center justify-center bg-gray-100 p-4 text-center text-black overflow-auto [transform:rotateY(180deg)] [backface-visibility:hidden]"
-          style={{ width: PANEL_WIDTH, height: panelHeight, boxSizing: 'border-box' }}
-        >
+        <div className="absolute inset-0 flex items-center justify-center bg-gray-100 p-4 text-center text-black overflow-auto [transform:rotateY(180deg)] [backface-visibility:hidden]">
           <p className="font-comic m-0">{history}</p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- compute panel aspect ratio once and apply via style
- anchor flip container absolutely inside a relative wrapper for precise alignment

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1849cbccc832ab683770debbfc705