### PR TITLE
Render ComicPanel block container

### DIFF
--- a/components/ComicPanel.tsx
+++ b/components/ComicPanel.tsx
@@ -13,31 +13,34 @@ interface ComicPanelProps {
 
 export default function ComicPanel({ src, alt, width, height, history }: ComicPanelProps) {
   const [flipped, setFlipped] = useState(false)
-  const aspect = width / height
 
   return (
-    <div
-      className="cursor-pointer [perspective:1000px] inline-block m-4 w-full max-w-[800px] relative"
-      style={{ aspectRatio: aspect }}
-      onClick={() => setFlipped(f => !f)}
-    >
+    <div className="not-prose">
       <div
-        className={`absolute inset-0 w-full h-full transition-transform duration-500 [transform-style:preserve-3d] ${
-          flipped ? '[transform:rotateY(180deg)]' : ''
-        }`}
+        className="cursor-pointer [perspective:1000px] block m-4 w-full max-w-[800px] relative"
+        style={{ aspectRatio: `${width} / ${height}` }}
+        onClick={() => setFlipped(f => !f)}
       >
-        <div className="[backface-visibility:hidden] absolute inset-0 w-full h-full">
-          <Image
-            src={src}
-            alt={alt}
-            fill
-            priority
-            className="object-contain"
-            sizes="(max-width: 800px) 100vw, 800px"
-          />
-        </div>
-        <div className="absolute inset-0 flex items-center justify-center bg-gray-100 p-4 text-center text-black overflow-auto [transform:rotateY(180deg)] [backface-visibility:hidden]">
-          <p className="font-comic m-0">{history}</p>
+        <div
+          className={`relative w-full h-full transition-transform duration-500 [transform-style:preserve-3d] ${
+            flipped ? '[transform:rotateY(180deg)]' : ''
+          }`}
+        >
+          {/* Front */}
+          <div className="[backface-visibility:hidden] absolute inset-0">
+            <Image
+              src={src}
+              alt={alt}
+              fill
+              priority
+              className="object-contain"
+              sizes="(max-width: 800px) 100vw, 800px"
+            />
+          </div>
+          {/* Back */}
+          <div className="absolute inset-0 flex items-center justify-center bg-gray-100 p-4 text-center text-black overflow-auto [transform:rotateY(180deg)] [backface-visibility:hidden]">
+            <p className="font-comic m-0">{history}</p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- switch ComicPanel wrapper to block layout
- restore aspect ratio variable and adjust transform wrappers
- wrap panel markup in a not-prose container
- compute aspect ratio inline to fix compile error

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c18f4fe190832ab17d4cf9f762372f