### PR TITLE
Render ComicPanel block container

### DIFF
--- a/components/ComicPanel.tsx
+++ b/components/ComicPanel.tsx
@@ -1,45 +1,47 @@
 'use client'
 
-import Image from 'next/image'
 import { useState } from 'react'
 
 interface ComicPanelProps {
   src: string
   alt: string
-  width: number
-  height: number
   history: string
 }
 
-export default function ComicPanel({ src, alt, width, height, history }: ComicPanelProps) {
+export default function ComicPanel({ src, alt, history }: ComicPanelProps) {
   const [flipped, setFlipped] = useState(false)
-  const aspect = width / height
+  const [imgHeight, setImgHeight] = useState<number | null>(null)
 
   return (
-    <div
-      className="cursor-pointer [perspective:1000px] inline-block m-4 w-full max-w-[800px] relative"
-      style={{ aspectRatio: aspect }}
-      onClick={() => setFlipped(f => !f)}
-    >
+    <div className="not-prose">
       <div
-        className={`absolute inset-0 w-full h-full transition-transform duration-500 [transform-style:preserve-3d] ${
-          flipped ? '[transform:rotateY(180deg)]' : ''
-        }`}
+        className="cursor-pointer [perspective:1000px] block m-4 w-full max-w-[800px] mx-auto"
+        onClick={() => setFlipped(f => !f)}
       >
-        <div className="[backface-visibility:hidden] absolute inset-0 w-full h-full">
-          <Image
-            src={src}
-            alt={alt}
-            fill
-            priority
-            className="object-contain"
-            sizes="(max-width: 800px) 100vw, 800px"
-          />
-        </div>
-        <div className="absolute inset-0 flex items-center justify-center bg-gray-100 p-4 text-center text-black overflow-auto [transform:rotateY(180deg)] [backface-visibility:hidden]">
-          <p className="font-comic m-0">{history}</p>
+        {/* The flipping container's height is set dynamically
+            to exactly match the rendered image height */}
+        <div
+          className={`relative w-full transition-transform duration-500 [transform-style:preserve-3d] ${
+            flipped ? '[transform:rotateY(180deg)]' : ''
+          }`}
+          style={imgHeight ? { height: imgHeight } : undefined}
+        >
+          {/* Front */}
+          <div className="[backface-visibility:hidden]">
+            <img
+              src={src}
+              alt={alt}
+              className="w-full h-auto block"
+              onLoad={e => setImgHeight((e.target as HTMLImageElement).offsetHeight)}
+            />
+          </div>
+          {/* Back */}
+          <div className="absolute inset-0 flex items-center justify-center bg-gray-100 p-4 text-center text-black overflow-auto [transform:rotateY(180deg)] [backface-visibility:hidden]">
+            <p className="font-comic m-0">{history}</p>
+          </div>
         </div>
       </div>
     </div>
   )
 }
+


### PR DESCRIPTION
## Summary
- replace ComicPanel image with plain `<img>` and simplify props
- center panel in a fixed-width container while retaining flip animation
- simplify wrapper to size itself from the image's natural aspect ratio
- ensure the flip container's height matches the rendered image for accurate back-face positioning

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c18f4fe190832ab17d4cf9f762372f