### PR TITLE
Use comic-book font and layout for flipped panel text

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Bangers&display=swap');
 @import "tailwindcss";
 
 :root {

--- a/components/ComicPanel.tsx
+++ b/components/ComicPanel.tsx
@@ -36,8 +36,8 @@ export default function ComicPanel({ src, alt, history }: ComicPanelProps) {
             />
           </div>
           {/* Back */}
-          <div className="absolute inset-0 flex items-center justify-center bg-gray-100 p-4 text-center text-black overflow-auto [transform:rotateY(180deg)] [backface-visibility:hidden]">
-            <p className="font-comic m-0">{history}</p>
+          <div className="absolute inset-0 flex items-start justify-start bg-white p-6 text-left text-black overflow-auto [transform:rotateY(180deg)] [backface-visibility:hidden]">
+            <p className="font-comic font-bold text-3xl sm:text-4xl md:text-5xl leading-tight m-0">{history}</p>
           </div>
         </div>
       </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,7 +5,7 @@ const config: Config = {
   theme: {
     extend: {
       fontFamily: {
-        comic: ['"Comic Sans MS"', 'Comic Sans', 'cursive'],
+        comic: ['Bangers', 'cursive'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- Import Bangers comic font and register it with Tailwind
- Restyle flipped panel back side text to top-aligned, bold, and oversized for classic comic-book feel

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1f9fad2a8832a84ca6268b282fb5d