### PR TITLE
Fix mobile layout on homepage

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="bg-background text-foreground flex flex-col items-center text-center">{children}</body>
+      <body className="bg-background text-foreground flex flex-col text-center">{children}</body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,9 +34,9 @@ async function getStories(): Promise<Story[]> {
 export default async function Home() {
   const stories = await getStories()
   return (
-    <main className="p-4 text-center flex flex-col items-center">
+    <main className="p-4 text-center flex flex-col">
       <Image src={logo} alt="Site logo" className="mb-4 mx-auto" />
-      <section className="prose mb-8 text-left max-w-3xl mx-auto">
+      <section className="prose mb-8 text-left max-w-3xl w-full mx-auto">
         <p>
           This site is a haunted rummage through time, dressed up like a comic
           strip and soaked in a bath of dread. Each story’s a grubby little relic

--- a/components/StoryCarousel.tsx
+++ b/components/StoryCarousel.tsx
@@ -9,7 +9,7 @@ export type Story = {
 
 export default function StoryCarousel({ stories }: { stories: Story[] }) {
   return (
-    <div className="overflow-x-auto mx-auto">
+    <div className="overflow-x-auto mx-auto w-full">
       <ul className="flex justify-center space-x-4 snap-x snap-mandatory">
         {stories.map(({ slug, title, cover }) => (
           <li


### PR DESCRIPTION
## Summary
- remove cross-axis centering that forced wide layout on small screens
- ensure story carousel and intro section stretch to full width

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1fda0d6c4832a88b5bdca15af7e50